### PR TITLE
add an itd snippet

### DIFF
--- a/src/Snippets/JasmineSnippetPack/itd.snippet
+++ b/src/Snippets/JasmineSnippetPack/itd.snippet
@@ -1,0 +1,26 @@
+﻿<CodeSnippet Format="1.1.0" xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <Header>
+    <Title>itd</Title>
+    <Shortcut>itd</Shortcut>
+    <Author>Kevin Logan - @aligneddev</Author>
+    <Description>Jasmine - creates an asynchronous test method</Description>
+    <SnippetTypes>
+      <SnippetType>Expansion</SnippetType>
+    </SnippetTypes>
+  </Header>
+  <Snippet>
+    <Declarations>
+      <Literal>
+        <ID>name</ID>
+        <ToolTip></ToolTip>
+        <Default>should behave...</Default>
+      </Literal>
+    </Declarations>
+    <Code Language="JavaScript">
+      <![CDATA[it('$name$', function(done) {
+        done();
+  $end$
+});]]>
+    </Code>
+  </Snippet>
+</CodeSnippet>


### PR DESCRIPTION
I'm often testing methods that return promises.

This snippet will enable `itd` to create
```
it('should behave...', function(done){
  done();
});
```

I'll also add a Typescript version to my other PR.