### PR TITLE
Remove specific ref. to '2015' version of Extensibility Tools in ReadMe.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ if you want to contribute to this project.
 
 For cloning and building this project yourself, make sure
 to install the
-[Extensibility Tools 2015](https://visualstudiogallery.msdn.microsoft.com/ab39a092-1343-46e2-b0f1-6a3f91155aa6)
+[Extensibility Tools](https://visualstudiogallery.msdn.microsoft.com/ab39a092-1343-46e2-b0f1-6a3f91155aa6)
 extension for Visual Studio which enables some features
 used by this project.
 


### PR DESCRIPTION
Remove specific reference to '2015' version of Extensibility Tools in ReadMe.MD